### PR TITLE
Remove fallback-x11 socket from KVIrc config

### DIFF
--- a/net.kvirc.KVIrc.yaml
+++ b/net.kvirc.KVIrc.yaml
@@ -9,7 +9,6 @@ command: kvirc
 finish-args:
   - --share=network
   - --socket=wayland
-  - --socket=fallback-x11
   - --share=ipc
   - --device=dri
   - --filesystem=xdg-download


### PR DESCRIPTION
Given KDE Plasma's clear direction toward Wayland and away from X11, we should now focus on deprecating or removing this item.

Reverts #12

PS #11 , #10 and https://github.com/flathub-infra/flatpak-builder-lint/pull/308